### PR TITLE
Update JenkinsfileTemplate to rename pip.zip without error

### DIFF
--- a/Automation and Build Server/Template Files/JenkinsfileTemplate
+++ b/Automation and Build Server/Template Files/JenkinsfileTemplate
@@ -35,7 +35,7 @@ pipeline {
         stage('Build AS Project') {
 			steps {
 				BuildASProject(project: "${PROJECT_DIR}", configuration: "${CONFIG_NAME}", max_warnings: -1, buildpip: true);
-                		powershell(returnStdout: true, script: "Move-Item -Path PIP.zip -Destination PIP-${RELEASE_VERSION}.zip -Force");
+				powershell(returnStdout: true, script: "Move-Item -Path PIP.zip -Destination PIP-${RELEASE_VERSION}.zip -Force");
 			}
         }
         stage('Unit Tests') {

--- a/Automation and Build Server/Template Files/JenkinsfileTemplate
+++ b/Automation and Build Server/Template Files/JenkinsfileTemplate
@@ -35,7 +35,7 @@ pipeline {
         stage('Build AS Project') {
 			steps {
 				BuildASProject(project: "${PROJECT_DIR}", configuration: "${CONFIG_NAME}", max_warnings: -1, buildpip: true);
-                powershell(returnStdout: true, script: "Rename-Item -Path PIP.zip -NewName PIP-${RELEASE_VERSION}.zip");
+                		powershell(returnStdout: true, script: "Move-Item -Path PIP.zip -Destination PIP-${RELEASE_VERSION}.zip -Force");
 			}
         }
         stage('Unit Tests') {


### PR DESCRIPTION
Move-Item -Force instead of Rename-Item allows for rename even if destination file already exists. this is needed because no complete workspace cleanup is performed in this jenkinsfile