### PR TITLE
.gitignore Safety project: Fix global variable file will get corrupted

### DIFF
--- a/Version Control/Template Files/.gitignore
+++ b/Version Control/Template Files/.gitignore
@@ -46,5 +46,6 @@
 # But include the required binary files:
 #!/Physical/*/*/*/C/PLC/R/CPU/src.st1
 #!/Physical/*/*/*/C/PLC/R/CPU/tmp.sto
+#!/Physical/*/*/*/C/PLC/R/CPU/GLOBAL_VARIABLESTranslation_SF.xml
 
 


### PR DESCRIPTION
Safety project, SafeDesigner: Do not ignore global variables translation or the global variable file will get corrupted.

Error:
![image](https://github.com/user-attachments/assets/5ab87fcf-6c8c-4a7e-9563-b29b07875b27)

Solution:
Not ignoring the `GLOBAL_VARIABLESTranslation_SF.xml` resolved this problem.
